### PR TITLE
Bump spring-boot-starter-parent from 2.1.7.RELEASE to 2.2.1.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.7.RELEASE</version>
+		<version>2.2.1.RELEASE</version>
 		<relativePath />
 	</parent>
 


### PR DESCRIPTION
Bumps spring-boot-starter-parent from 2.1.7.RELEASE to 2.2.1.RELEASE.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>